### PR TITLE
Support a secondary secret from the client application

### DIFF
--- a/lib/oauth/controllers/provider_controller.rb
+++ b/lib/oauth/controllers/provider_controller.rb
@@ -34,7 +34,12 @@ module OAuth
 
       def token
         @client_application = ClientApplication.find_by_key! params[:client_id]
-        if @client_application.secret != params[:client_secret]
+        secrets = if @client_application.has_attribute(:secondary_secret)
+                    [@client_application.secret, @client_application.secondary_secret]
+                  else
+                    [@client_application.secret]
+                  end
+        unless secrets.any?(param[:client_secret])
           oauth2_error "invalid_client"
           return
         end

--- a/spec/dummy_provider_models.rb
+++ b/spec/dummy_provider_models.rb
@@ -17,7 +17,10 @@ class ClientApplication
   def secret
     "secret"
   end
+end
 
+# FIXME: would be good to test against this but the authorizer expects the base type directly
+class SecondaryClientApplication < ClientApplication
   def secondary_secret
     "secondarysecret"
   end

--- a/spec/dummy_provider_models.rb
+++ b/spec/dummy_provider_models.rb
@@ -17,6 +17,10 @@ class ClientApplication
   def secret
     "secret"
   end
+
+  def secondary_secret
+    "secondarysecret"
+  end
 end
 
 class OauthToken

--- a/spec/oauth/provider/authorizer_spec.rb
+++ b/spec/oauth/provider/authorizer_spec.rb
@@ -34,6 +34,21 @@ describe OAuth::Provider::Authorizer do
 
       end
 
+      # it "should allow for a secondary secret" do
+      #   ::Oauth2Verifier.should_receive(:create!).with(:client_application=>@app,
+      #                                                  :user=>@user,
+      #                                                  :callback_url=>'http://mysite.com/callback',
+      #                                                  :scope => 'a b').and_return(@code)
+      #
+      #   @authorizer = OAuth::Provider::Authorizer.new @user, true, :response_type => 'code',
+      #                                                 :scope => "a b",
+      #                                                 :client_id => 'client id',
+      #                                                 :redirect_uri => 'http://mysite.com/callback'
+      #
+      #   @authorizer.redirect_uri.should == "http://mysite.com/callback?code=secondarysecret%20auth%20code"
+      #   @authorizer.should be_authorized
+      # end
+
       it "should include state" do
         ::Oauth2Verifier.should_receive(:create!).with( :client_application=>@app,
                                                   :user=>@user,


### PR DESCRIPTION
### Description

Adds a check for a secondary secret on the client application if the attribute exists on the instance. This is being added as part of work in the `manage` application to be able to rotate a client application secret and maintain a fallback.

**Acceptance Criteria**

- [ ] OAuth mechanisms in the `manage` application continue to work as expected
- [ ] A secondary secret that has been added to a client application can be used for authorization

### Test Plan

- [ ] make the following change to `Gemfile` in the `manage` repository

```diff
-gem "oauth-plugin", git: "https://github.com/clio/oauth-plugin.git", ref: "74f400ed5dacc516d1e2fff952e9b4f3664fda27"
+gem "oauth-plugin", git: "https://github.com/clio/oauth-plugin.git", ref: "ecbf46c4cda3f6c60376829600933e1c8cf3d5ba"
```

- [ ] execute `bundle install`
- [ ] use the localhost development address as `<dev_addr>` in the following steps
- [ ] go to http://<dev_addr>/settings/developer_applications
- [ ] copy the app secret and key for one of the applications, the key is below as `<client_id>` and secret as `<client_secret>`
- [ ] go to http://<dev_addr>/oauth/authorize?response_type=code&client_id=<client_id>&redirect_uri=http://<dev_addr>/oauth/approval
- [ ] on the page displaying scopes click the button to "Allow Access"
- [ ] copy the code that's given on the next screen to use below as `<code>`
- [ ] execute the command

```shell
curl -X POST \
  -c ~/.clio-session \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "client_secret=<client_secret>" \
  -d "client_id=<client_id>" \
  -d "redirect_uri=http://<dev_addr>/oauth/approval" \
  -d "grant_type=authorization_code" \
  -d "code=<code>" \
  http://<dev_addr>/oauth/token
```

- [ ] copy the value for `access_token` that's output and use below as `<access_token>`
- [ ] test a call to the API with the command

```shell
curl -b ~/.clio-session \
  -H "Authorization: Bearer <access_token>" \
  http://<dev_addr>/api/v4/users/who_am_i
```

- [ ] the call should complete successfully, functionality added in this PR should not change what is already working