### PR TITLE
update this library's deps

### DIFF
--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test"
 
   s.add_dependency "multi_json"
-  s.add_dependency("oauth", ["~> 0.4.4"])
+  s.add_dependency("oauth", ["~> 0.5.6"])
   s.add_dependency("rack")
   s.add_dependency("oauth2")
 end


### PR DESCRIPTION
Related to https://github.com/clio/security-vulnerabilities/issues/330

This updates the `oauth` dependency to require `0.5.6`.